### PR TITLE
Update serializer to account for doubles

### DIFF
--- a/packages/firestore_doc/lib/src/serialization/server_date_time_serializer.dart
+++ b/packages/firestore_doc/lib/src/serialization/server_date_time_serializer.dart
@@ -17,7 +17,7 @@ class ServerDateTimeSerializer extends PrimitiveSerializer<DateTime> {
   @override
   DateTime deserialize(Serializers serializers, Object serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    var microsecondsSinceEpoch = serialized as int;
+    var microsecondsSinceEpoch = (serialized as double).floor();
     return DateTime.fromMicrosecondsSinceEpoch(
       microsecondsSinceEpoch,
       isUtc: true,


### PR DESCRIPTION
I'm using this package in another project right now, and sometimes timestamps that come back from a remote function come back as a double, rather than an int.