### PR TITLE
Allow timestamp to come back as either double or int.

### DIFF
--- a/packages/firestore_doc/lib/src/serialization/server_date_time_serializer.dart
+++ b/packages/firestore_doc/lib/src/serialization/server_date_time_serializer.dart
@@ -17,7 +17,7 @@ class ServerDateTimeSerializer extends PrimitiveSerializer<DateTime> {
   @override
   DateTime deserialize(Serializers serializers, Object serialized,
       {FullType specifiedType = FullType.unspecified}) {
-    var microsecondsSinceEpoch = serialized as int;
+   var microsecondsSinceEpoch = serialized is int ? serialized as int : serialized is double ? serialized.floor() : null;
     return DateTime.fromMicrosecondsSinceEpoch(
       microsecondsSinceEpoch,
       isUtc: true,


### PR DESCRIPTION
Currently my RemoteFunctions sometimes return values with timestamps as doubles.  This allows those to be converted to datetime as well